### PR TITLE
Fix cpu

### DIFF
--- a/da-clip/src/open_clip/transformer.py
+++ b/da-clip/src/open_clip/transformer.py
@@ -294,7 +294,7 @@ class ControlTransformer(nn.Module):
 
         self.zero_modules =  nn.ModuleList([
             self.zero_module(nn.Linear(self.width, self.width, 1))
-            for _ in range(self.layers)]).cuda()
+            for _ in range(self.layers)])
         self.grad_checkpointing = transformer.grad_checkpointing
 
     def zero_module(self, module):


### PR DESCRIPTION
Fix https://github.com/Algolzw/daclip-uir/issues/21 by simply eliminating the explicit conversion of zero_modules to cuda.

As far as I see `create_model` will take care of moving everything to cuda https://github.com/Algolzw/daclip-uir/blob/a4e6720fcbf27c3e99840990bea1e9fbb67710dc/da-clip/src/open_clip/factory.py#L219